### PR TITLE
Fix for SORT_BAM step failing

### DIFF
--- a/modules/process/sort_bam_samtools.nf
+++ b/modules/process/sort_bam_samtools.nf
@@ -11,6 +11,6 @@ process SORT_BAM {
 
     script:
     """
-    samtools view -@ ${task.cpus} -bh -F 0x200 -F 0x4 | samtools sort -@ ${task.cpus} -o ${bam.baseName}.sorted.bam $bam
+    samtools view -@ ${task.cpus} -bh -F 0x200 -F 0x4 $bam | samtools sort -@ ${task.cpus} -o ${bam.baseName}.sorted.bam
     """
 }


### PR DESCRIPTION
Moved the $bam argument to samtools view, which otherwise gets no input data and causes the step to fail. Seems like the bug was introduced in commit 1a2e962, when always sorting bam files was added. This fixes the issue.